### PR TITLE
Bug missing spec

### DIFF
--- a/src/qutip_cuquantum/operator.py
+++ b/src/qutip_cuquantum/operator.py
@@ -757,7 +757,7 @@ def identity_like(data, /):
 
 
 @_data.iszero.register(CuOperator)
-def iszero_CuOperator(state):
+def iszero_CuOperator(state, tol=...):
     for term in state.terms:
         if term.factor != 0:
             return False

--- a/src/qutip_cuquantum/operator.py
+++ b/src/qutip_cuquantum/operator.py
@@ -755,6 +755,18 @@ def identity_like(data, /):
     new.terms.append(Term([], 1.))
     return new
 
+
+@_data.iszero.register(CuOperator)
+def iszero_CuOperator(state):
+    for term in state.terms:
+        if term.factor != 0:
+            return False
+        # TODO:
+        # Add check for cases where Elementary matrices are zeros
+        # Add check for cancelling terms
+    return True
+
+
 ###############################################################################
 ###############################################################################
 

--- a/src/qutip_cuquantum/qobjevo.py
+++ b/src/qutip_cuquantum/qobjevo.py
@@ -21,8 +21,7 @@ class CuQobjEvo(QobjEvo):
     def __init__(self, qobjevo):
         qobjevo = qobjevo.to(CuOperator)
         as_list = qobjevo.to_list()
-        self._dims = qobjevo._dims
-        self.shape = qobjevo.shape
+        super().__init__(qobjevo)
         self.action_ready = False
         self.expect_ready = False
         if qobjevo.issuper:
@@ -49,7 +48,6 @@ class CuQobjEvo(QobjEvo):
             else:
                 oper = wrap_funcelement(*part, dual, self.hilbert_space_dims)
                 self.operator.append(oper)
-
 
     def matmul_data(self, t, state, out=None, scale=1.):
         if scale != 1.:

--- a/src/qutip_cuquantum/state.py
+++ b/src/qutip_cuquantum/state.py
@@ -260,6 +260,11 @@ def trace_cuState(mat):
     return complex(mat.base.trace()[0])
 
 
+@_data.trace_oper_ket.register(CuState)
+def trace_oper_ket_cuState(mat):
+    return complex(mat.base.trace()[0])
+
+
 @_data.inner.register(CuState)
 def inner_cuState(left, right, scalar_is_ket=False):
     if left.shape == (1, 1) and not scalar_is_ket:
@@ -351,8 +356,14 @@ def isherm(state, tol=-1):
     return cp.allclose(cupy_view, cupy_view.T.conj(), atol=tol)
 
 
+@_data.zeros_like.register(CuState)
 def zeros_like_cuState(state):
-    return CuState(state.base.clone(cp.zeros_like(state.base.storage, order="F")))
+    return CuState(
+        state.base.clone(cp.zeros_like(state.base.storage, order="F")),
+        state.base.hilbert_space_dims,
+        shape = state.shape
+    )
+
 
 @_data.conj.register(CuState)
 def conj_cuState(state):
@@ -387,7 +398,6 @@ def matmul_cuState(left, right, scale=1):
         )
 
     output_shape = (left.shape[0], right.shape[1])
-    ctx = settings.cuDensity["ctx"]
     if(left.shape[0] == 1 and right.shape[1] == 1):
         # Scalar case
         hilbert_dims = (1,)
@@ -397,5 +407,22 @@ def matmul_cuState(left, right, scale=1):
     left_array = left.to_cupy()
     right_array = right.to_cupy()
     arr = left_array @ right_array * scale
+
+    return CuState(arr, hilbert_dims=hilbert_dims, shape=output_shape)
+
+
+@_data.project.register(CuState)
+def project_CuState(pure):
+    if pure.shape[1] != 1:
+        pure = pure.adjoint()
+    if pure.shape[1] != 1:
+        raise ValueError("state must be a ket or a bra.")
+
+    output_shape = (pure.shape[0], pure.shape[0])
+    hilbert_dims = pure.base.hilbert_space_dims
+
+    left = pure.to_cupy()
+    right = left.T.conj()
+    arr = left @ right
 
     return CuState(arr, hilbert_dims=hilbert_dims, shape=output_shape)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -5,7 +5,7 @@ import random
 cudense = pytest.importorskip("cuquantum.densitymat")
 
 import qutip
-from qutip_cuquantum.operator import CuOperator
+from qutip_cuquantum.operator import CuOperator, isequal_CuOperator
 from qutip_cuquantum.state import zeros_like_cuState, CuState
 
 import qutip.core.data as _data
@@ -134,7 +134,7 @@ def _cplx(N):
 def test_equal(left, right, expected):
     left = left()
     right = right()
-    assert (left.data == right.data) is expected
+    assert (isequal_CuOperator(left.data, right.data)) is expected
 
 
 class TestAdd(test_tools.TestAdd):
@@ -158,7 +158,7 @@ class TestSub(test_tools.TestSub):
 class TestMatmul(test_tools.TestMatmul):
     specialisations = [
         pytest.param(
-            lambda x, y, scale=1.: x @ y * scale, 
+            lambda x, y, scale=1.: x @ y * scale,
             CuOperator, CuOperator, CuOperator
     )]
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -13,8 +13,9 @@ cudense = pytest.importorskip("cuquantum.densitymat")
 import qutip
 from qutip_cuquantum.state import (
     CuState, iadd_cuState, add_cuState, mul_cuState, imul_cuState, l2_cuState,
-    frobenius_cuState, trace_cuState, inner_cuState, wrmn_error_cuState,
-    transpose_cuState, adjoint_cuState, matmul_cuState
+    frobenius_cuState, trace_cuState, trace_oper_ket_cuState,
+    inner_cuState, wrmn_error_cuState,
+    transpose_cuState, adjoint_cuState, matmul_cuState, project_CuState
 )
 
 import qutip.core.data as _data
@@ -114,14 +115,14 @@ _matmul_incompatible = [
         pytest.param((2, 12, StateType.DM), id="2,12 dm"),
     ),
     (
-        pytest.param((2, 3, StateType.KET), id="2,3 ket"),        
+        pytest.param((2, 3, StateType.KET), id="2,3 ket"),
         pytest.param((2, 3, StateType.DM), id="2,3 dm"),
     ),
     (
-        pytest.param((2, 3, StateType.DM), id="2,3 dm"),                    
-        pytest.param((2, 3, StateType.BRA), id="2,3 bra"),        
+        pytest.param((2, 3, StateType.DM), id="2,3 dm"),
+        pytest.param((2, 3, StateType.BRA), id="2,3 bra"),
 
-    ),    
+    ),
 ]
 
 _kron_hilbert = [
@@ -149,7 +150,16 @@ _kron_hilbert = [
 
 class TestTrace(test_tools.TestTrace):
     specialisations = [
-        pytest.param(trace_cuState, CuState, CuState, complex),
+        pytest.param(trace_cuState, CuState, complex),
+    ]
+
+    shapes = _unary_mixed
+    bad_shapes = []
+
+
+class TestTrace(test_tools.TestTrace_oper_ket):
+    specialisations = [
+        pytest.param(trace_oper_ket_cuState, CuState, complex),
     ]
 
     shapes = _unary_mixed
@@ -237,6 +247,15 @@ class TestMatmul(test_tools.TestMatmul):
 
     shapes = _matmul_compatible
     bad_shapes = _matmul_incompatible
+
+
+class TestProject(test_tools.TestProject):
+    specialisations = [
+        pytest.param(project_CuState, CuState, CuState),
+    ]
+
+    shapes = _unary_pure
+    bad_shapes = _unary_mixed
 
 
 def test_isherm():

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -151,14 +151,7 @@ _kron_hilbert = [
 class TestTrace(test_tools.TestTrace):
     specialisations = [
         pytest.param(trace_cuState, CuState, complex),
-    ]
-
-    shapes = _unary_mixed
-    bad_shapes = []
-
-
-class TestTrace(test_tools.TestTrace_oper_ket):
-    specialisations = [
+        # OperKet are not actually stacked in the tensor rep
         pytest.param(trace_oper_ket_cuState, CuState, complex),
     ]
 


### PR DESCRIPTION
Fix missing specialization for qutip 5.3:
- `iszero` for `qobjevo.compress`
- Set cython attributes indirectly to avoid needing to use cython.
- `project`, 'trace_oper_ket` without passing by cpu.